### PR TITLE
Case insensitive matching of access-control-request-headers

### DIFF
--- a/lib/corser.js
+++ b/lib/corser.js
@@ -106,7 +106,7 @@ exports.create = function (options) {
                         // empty list. If parsing failed do not set any additional headers and terminate this set
                         // of steps.
                         if (req.headers.hasOwnProperty("access-control-request-headers")) {
-                            requestHeaders = req.headers["access-control-request-headers"].split(/,\s*/);
+                            requestHeaders = toLowerCase(req.headers["access-control-request-headers"].split(/,\s*/));
                         } else {
                             requestHeaders = [];
                         }


### PR DESCRIPTION
Hi,

please consider pulling this change. We had problems with Safari not getting any CORS headers at all from our app. It turns out that corser wasn't matching the capitalized header names provided by the browser (i.e. "Accept" instead of "accept")
