### PR TITLE
added chrome workaround for Access-Control-Request-Headers with empty string

### DIFF
--- a/lib/corser.js
+++ b/lib/corser.js
@@ -126,7 +126,8 @@ exports.create = function (options) {
                                 // If there are no Access-Control-Request-Headers headers let header field-names be the
                                 // empty list. If parsing failed do not set any additional headers and terminate this set
                                 // of steps.
-                                if (req.headers.hasOwnProperty("access-control-request-headers")) {
+                                // added Chrome Access-Control-Request-Headers workaround
+                                if (req.headers.hasOwnProperty("access-control-request-headers") && req.headers["access-control-request-headers"] !== "") {
                                     requestHeaders = toLowerCase(req.headers["access-control-request-headers"].split(/,\s*/));
                                 } else {
                                     requestHeaders = [];


### PR DESCRIPTION
See https://github.com/agrueneberg/Corser/issues/18