### PR TITLE
Fix an issue where non-matching preflight requests were not terminated.

### DIFF
--- a/lib/corser.js
+++ b/lib/corser.js
@@ -104,19 +104,24 @@ exports.create = function (options) {
                 if (err !== null) {
                     next(err);
                 } else {
+                    var endPreflight = function () {
+                        if (options.endPreflightRequests === true) {
+                            res.writeHead(204);
+                            res.end();
+                        } else {
+                            next();
+                        }
+                    };
+
                     if (typeof originMatches !== "boolean" || originMatches === false) {
-                        next();
+                        if (req.method === "OPTIONS") {
+                            endPreflight();
+                        } else {
+                            next();
+                        }
                     } else {
                         // Respond to preflight request.
                         if (req.method === "OPTIONS") {
-                            endPreflight = function () {
-                                if (options.endPreflightRequests === true) {
-                                    res.writeHead(204);
-                                    res.end();
-                                } else {
-                                    next();
-                                }
-                            };
                             // If there is no Access-Control-Request-Method header or if parsing failed, do not set
                             // any additional headers and terminate this set of steps.
                             if (!req.headers.hasOwnProperty("access-control-request-method")) {

--- a/test/corser-spec.js
+++ b/test/corser-spec.js
@@ -440,6 +440,19 @@ describe("Corser", function () {
             expect(res.ended).to.be(true);
         });
 
+        it("should end preflight requests that do not match", function () {
+            var requestListener;
+            requestListener = corser.create({
+              origins: function(origin, callback) { callback(null, false) },
+              endPreflightRequests: true
+            });
+            req.headers["origin"] = "example.org";
+            req.headers["access-control-request-method"] = "GET";
+            requestListener(req, res);
+            expect(res.status).to.be(204);
+            expect(res.ended).to.be(true);
+        });
+
     });
 
 });


### PR DESCRIPTION
Came across an issue where a preflight request that did not match an allowed-origin was not ended when the `endPreflightRequests` flag was true.

If an `OPTIONS` request is not matched with `endPrefilghtRequests` set to true, it is unlikely that the lib user wants to handle it his/herself and it would be difficult to take any meaningful action.

Tests added,

Cheers!